### PR TITLE
feat: add method for removing device owner

### DIFF
--- a/src/internal/Device.ts
+++ b/src/internal/Device.ts
@@ -1,3 +1,4 @@
+import { assert } from "../deps/std_testing_asserts.ts";
 import type * as models from "../models/mod.ts";
 import type { BasicObjectInit, Creator } from "./Client.ts";
 import { suppressAPIError } from "./APIError.ts";
@@ -124,6 +125,10 @@ export class Device implements models.Device {
 	}
 
 	async setOwner(user: { id: number }) {
+		assert(
+			user.id !== 0,
+			"Using ID 0 would remove the owner. If this is intentional, use `Device.removeOwner()`",
+		);
 		if (user.id !== this.#data.owner.id) {
 			await this.#api.assignDeviceOwner(this.udid, user.id);
 		}

--- a/src/internal/Device.ts
+++ b/src/internal/Device.ts
@@ -130,6 +130,13 @@ export class Device implements models.Device {
 		return this;
 	}
 
+	async removeOwner() {
+		if (this.#data.owner.id !== 0) {
+			await this.#api.assignDeviceOwner(this.udid, 0);
+		}
+		return this;
+	}
+
 	async getGroups(): Promise<models.DeviceGroup[]> {
 		let allGroups;
 		try {

--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -126,6 +126,9 @@ export interface Device {
 	 */
 	setOwner(user: { id: number }): Promise<this>;
 
+	/** (Edit) Remove this device's owner. */
+	removeOwner(): Promise<this>;
+
 	/** (Read) Get the device's groups. */
 	getGroups(): Promise<DeviceGroup[]>;
 


### PR DESCRIPTION
This disallows `Device.setOwner({ id: 0 })`, and adds a new method, `Device.removeOwner()`. The intention is much clearer, and it cannot be done accidentally.