### PR TITLE
feat: add AJV compile shim for releases

### DIFF
--- a/scripts/ajv_compile_shim.js
+++ b/scripts/ajv_compile_shim.js
@@ -1,0 +1,40 @@
+import ajv from "../src/schemas/_ajv_jtd.ts";
+
+// This shim recursively adds the additionalProperties prop to schemas
+// before they're compiled, because release builds shouldn't be as strict
+// as dev builds. Additional properties are acceptable in production.
+
+const realCompile = ajv.compile.bind(ajv);
+
+if (Deno.env.get("BUNDLE_RELEASE") === "1") {
+	ajv.compile = function (...args) {
+		const [schema] = args;
+		recurisvelyAddAdditionalProps(schema);
+		return realCompile(...args);
+	};
+	ajv.compile.prototype = realCompile.prototype;
+}
+
+const recurisvelyAddAdditionalProps = (object) => {
+	if ("properties" in object || "optionalProperties" in object) {
+		object.additionalProperties = true;
+		for (const value of Object.values(object.properties ?? {})) {
+			recurisvelyAddAdditionalProps(value);
+		}
+		for (const value of Object.values(object.optionalProperties ?? {})) {
+			recurisvelyAddAdditionalProps(value);
+		}
+	} else if ("elements" in object) {
+		recurisvelyAddAdditionalProps(object.elements);
+	} else if ("values" in object) {
+		recurisvelyAddAdditionalProps(object.values);
+	} else if ("mapping" in object) {
+		for (const value of Object.values(object.mapping)) {
+			recurisvelyAddAdditionalProps(value);
+		}
+	} else if ("definitions" in object) {
+		for (const value of Object.values(object.definitions)) {
+			recurisvelyAddAdditionalProps(value);
+		}
+	}
+};

--- a/scripts/ajv_compile_shim.js
+++ b/scripts/ajv_compile_shim.js
@@ -18,12 +18,14 @@ if (isRelease) {
 }
 
 const recurisvelyAddAdditionalProps = (object) => {
-	if ("properties" in object || "optionalProperties" in object) {
-		object.additionalProperties = true;
-		for (const value of Object.values(object.properties ?? {})) {
+	if ("properties" in object) {
+		object.additionalProperties ??= true;
+		for (const value of Object.values(object.properties)) {
 			recurisvelyAddAdditionalProps(value);
 		}
-		for (const value of Object.values(object.optionalProperties ?? {})) {
+	} else if ("optionalProperties" in object) {
+		object.additionalProperties ??= true;
+		for (const value of Object.values(object.optionalProperties)) {
 			recurisvelyAddAdditionalProps(value);
 		}
 	} else if ("elements" in object) {

--- a/scripts/ajv_compile_shim.js
+++ b/scripts/ajv_compile_shim.js
@@ -6,7 +6,9 @@ import ajv from "../src/schemas/_ajv_jtd.ts";
 
 const realCompile = ajv.compile.bind(ajv);
 
-if (Deno.env.get("BUNDLE_RELEASE") === "1") {
+export const isRelease = Deno.env.get("BUNDLE_RELEASE") === "1";
+
+if (isRelease) {
 	ajv.compile = function (...args) {
 		const [schema] = args;
 		recurisvelyAddAdditionalProps(schema);

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -11,8 +11,8 @@ import { colorizeConsole } from "./deps/colorize.ts";
 import ajv from "../src/schemas/_ajv_jtd.ts";
 import standaloneCode from "../src/deps/ajv_standalone.ts";
 
-// This shim has to be imported before any of the schemas are compiled.
-import "./ajv_compile_shim.js";
+// This shim must be imported before any of the schemas are compiled.
+import { isRelease } from "./ajv_compile_shim.js";
 
 import * as schemas from "../src/schemas/mod.ts";
 
@@ -120,6 +120,8 @@ console.debug(`Wrote validators in ${timeWritingValidators()} ms`);
 const banner = `
 /// <reference types="./mod.ts" />
 
+// Bundle mode: ${isRelease ? "release" : "development"}
+
 // dprint-ignore-file
 // deno-lint-ignore-file
 
@@ -165,3 +167,6 @@ const delta = newSize - oldSize;
 const sign = delta > 0 ? "+" : "";
 
 console.info(`${repo(outFile)} changed by ${sign}${delta}B`);
+if (isRelease) {
+	console.info(`Bundled as release (additionalProperties is always true)`);
+}

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -10,6 +10,7 @@ import { colorizeConsole } from "./deps/colorize.ts";
 // but it's more consistent this way.
 import ajv from "../src/schemas/_ajv_jtd.ts";
 import standaloneCode from "../src/deps/ajv_standalone.ts";
+import "./ajv_compile_shim.js";
 
 import * as schemas from "../src/schemas/mod.ts";
 

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -10,6 +10,8 @@ import { colorizeConsole } from "./deps/colorize.ts";
 // but it's more consistent this way.
 import ajv from "../src/schemas/_ajv_jtd.ts";
 import standaloneCode from "../src/deps/ajv_standalone.ts";
+
+// This shim has to be imported before any of the schemas are compiled.
 import "./ajv_compile_shim.js";
 
 import * as schemas from "../src/schemas/mod.ts";

--- a/src/schemas/mod.bundle.js
+++ b/src/schemas/mod.bundle.js
@@ -1,5 +1,7 @@
 /// <reference types="./mod.ts" />
 
+// Bundle mode: development
+
 // dprint-ignore-file
 // deno-lint-ignore-file
 


### PR DESCRIPTION
Schemas were previously either too strict or too lenient. I want to be able to see additional properties as errors during development, but they should not be errors in releases - the schema should instead be a contract for the _minimum_ data that API will return, not _all_ the data it returns.

This PR adds a shim for `AJV.compile` that sets `additionalProperties` to true for each schema, before it's compiled. This only happens if the environment has `BUNDLE_RELEASE=1`.

To-do:

- [x] CI currently treats this as an error, since `BUNDLE_RELEASE=1` is only set during development. Maybe the bundle should include some kind of frontmatter that tells the check script how it was compiled?