### PR TITLE
feat: add module entry point in repo root

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,5 @@
+// src/mod.ts is the canonical entrypoint for this module.
+// This file exists so you can import from GitHub without
+// having to specify the src/ directory.
+
+export * from "./src/mod.ts";


### PR DESCRIPTION
This makes it easier to use from raw.githubusercontent.com (or via an alias service like denopkg.com), since previously you had to specify the `src` directory.

Before:
```
https://denopkg.com/SeparateRecords/deno_jamf_school/src/mod.ts
https://raw.githubusercontent.com/SeparateRecords/deno_jamf_school/main/src/mod.ts
```
After:
```
https://denopkg.com/SeparateRecords/deno_jamf_school/mod.ts
https://raw.githubusercontent.com/SeparateRecords/deno_jamf_school/main/mod.ts
```
_Wow, so much better! I'm going to use those 4 characters I saved to change the world._