### PR TITLE
feat: suggest identifiers in API.getDevices

### DIFF
--- a/src/deps/apple_device_identifiers.ts
+++ b/src/deps/apple_device_identifiers.ts
@@ -1,0 +1,1 @@
+export * from "https://raw.githubusercontent.com/SeparateRecords/apple_device_identifiers/fbd07920788d0541c571674dc8913b78f6c881b9/mod.ts";

--- a/src/models/API.ts
+++ b/src/models/API.ts
@@ -1,3 +1,4 @@
+import type { AnyIdentifier } from "../deps/apple_device_identifiers.ts";
 import type { RouteData } from "../schemas/mod.ts";
 
 /**
@@ -234,11 +235,11 @@ export interface APIGetDevicesOptions {
 	 * { modelIdentifier: "iPad11,6" }
 	 * ```
 	 *
-	 * This API provides a good, but non-comprehensive, list of device
-	 * identifiers and their human-readable names.
-	 * https://api.ipsw.me/v4/devices
+	 * Any string is valid, but not all strings are identifiers. If an invalid
+	 * identifier is given, no devices will be returned. Currently known valid
+	 * identifiers will be suggested in your editor.
 	 */
-	modelIdentifier?: string;
+	modelIdentifier?: AnyIdentifier;
 
 	/**
 	 * Select devices based on which location they have been assigned to.


### PR DESCRIPTION
I've been wanting to add this for so long. Nobody had created a list of all device identifiers, so I couldn't do it. Finally, with my shitloads of time off, I decided that _I'll_ make the list.

Any string can be used for this parameter, but it will eagerly suggest currently known identifiers.

![image](https://user-images.githubusercontent.com/52195359/134758187-e9edefbe-7af4-4c7b-9d57-42227695df55.png)
