### PR TITLE
refactor: better implementation of `Device.enrollment`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,17 +16,21 @@ All source code is located under the `src` directory. This is the directory that
 
 While this project follows most of the conventions of a modern Deno/TypeScript project, there are a few notable differences in structure that are important to be aware of.
 
+### Spelling
+
+Use American spellings. For example, "color" instead of "colour", "enroll" instead of "enrol".
+
+This helps keep the documentation and symbol naming consistent and predictable. The lion's share of English speakers are American, and likely the majority of Jamf School users are too.
+
 ### Formatting
 
-Instead of `deno fmt`, this project uses `dprint`. dprint is the backend for Deno formatter, and supports configuration - most of the settings from Deno are kept the same. Your platform's package manager probably lists it, but if not, compiling it from source isn't too hard (cargo install dprint).
-
-Before committing, run `dprint fmt`.
+Before committing, run `deno fmt --config deno.jsonc`. **Make sure to set the config file.**
 
 ### Indentation
 
 Please use tabs. Spaces are fine, and in fact for the first 90 commits, I was also using spaces. However, tabs allow you to configure the width in your editor to be just right for you. If that's two spaces, great! If that's 200 spaces, well- sure, you can do that. Dunno why you would, but you can.
 
-> **Pro tip:** On GitHub, append `?ts=4` to the URL to set the tab width to 4. It makes viewing code with tabs bearable if you hate 8-wide tabs, like me.
+On GitHub, you can change hard-tab width in your "Appearance" settings.
 
 ### Naming: What words should I use?
 

--- a/src/internal/Device.ts
+++ b/src/internal/Device.ts
@@ -3,33 +3,13 @@ import type * as models from "../models/mod.ts";
 import type { BasicObjectInit, Creator } from "./Client.ts";
 import { suppressAPIError } from "./APIError.ts";
 
-type Enrollment =
-	| "ac2"
-	| "ac2Pending"
-	| "dep"
-	| "depPending"
-	| "manual";
-
-type EnrollmentObject =
-	| { readonly type: "ac2" | "dep"; readonly pending: boolean }
-	| { readonly type: "manual" };
-
-function enrollmentToObject(enrollment: Enrollment): EnrollmentObject {
-	switch (enrollment) {
-		case "dep":
-			return { type: "dep", pending: false };
-		case "ac2":
-			return { type: "ac2", pending: false };
-		case "depPending":
-			return { type: "dep", pending: true };
-		case "ac2Pending":
-			return { type: "ac2", pending: true };
-		case "manual":
-			return { type: "manual" };
-		default:
-			throw new Error("Unreachable");
-	}
-}
+const enrollment = {
+	"ac2": { type: "ac2", pending: false } as const,
+	"dep": { type: "dep", pending: false } as const,
+	"ac2Pending": { type: "ac2", pending: true } as const,
+	"depPending": { type: "dep", pending: true } as const,
+	"manual": { type: "manual", pending: false } as const,
+} as const;
 
 // /devices and /devices/:udid both return subtly different data, but /devices
 // is the more sane of the two routes.
@@ -124,7 +104,7 @@ export class Device implements models.Device {
 	}
 
 	get enrollment() {
-		return enrollmentToObject(this.#data.enrollType);
+		return enrollment[this.#data.enrollType];
 	}
 
 	async update() {

--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -85,10 +85,16 @@ export interface Device {
 	 *
 	 * "ac2" is "Apple Configurator 2", which is Apple's software used to enroll
 	 * devices that were not purchased from a device reseller.
+	 *
+	 * "manual" is used for devices that have been enrolled by manually, either
+	 * using the "On-device enrollment" portal or by installing the management
+	 * profile. Currently, if the `type` is "manual", pending is guaranteed to be
+	 * false.
 	 */
-	readonly enrollment:
-		| { readonly type: "dep" | "ac2"; readonly pending: boolean }
-		| { readonly type: "manual" };
+	readonly enrollment: {
+		readonly type: "dep" | "ac2" | "manual";
+		readonly pending: boolean;
+	};
 
 	/**
 	 * The total capacity of the battery in watt-hours (Wh).

--- a/test/client/client.test.ts
+++ b/test/client/client.test.ts
@@ -7,136 +7,136 @@ const readRelativeTextFile = relativeTextFileReader(import.meta.url);
 const client = jamf.createClient({ id: "", token: "", url: "" });
 
 Deno.test({
-  name: "Client/createDevice: no apps",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile("../example_data/GET_devices__200.json"),
-    );
-    assertValid("GET /devices", data);
+	name: "Client/createDevice: no apps",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile("../example_data/GET_devices__200.json"),
+		);
+		assertValid("GET /devices", data);
 
-    data.devices.map(
-      (device) => client.createDevice(device),
-    );
-  },
+		data.devices.map(
+			(device) => client.createDevice(device),
+		);
+	},
 });
 
 Deno.test({
-  name: "Client/createDevice: with apps",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile("../example_data/GET_devices__200__apps.json"),
-    );
-    assertValid("GET /devices", data);
+	name: "Client/createDevice: with apps",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile("../example_data/GET_devices__200__apps.json"),
+		);
+		assertValid("GET /devices", data);
 
-    data.devices.map(
-      (device) => client.createDevice(device),
-    );
-  },
+		data.devices.map(
+			(device) => client.createDevice(device),
+		);
+	},
 });
 
 Deno.test({
-  name: "Client/createUser: single user data",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile("../example_data/GET_users_id__200.json"),
-    );
-    assertValid("GET /users/:id", data);
-    client.createUser(data.user);
-  },
+	name: "Client/createUser: single user data",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile("../example_data/GET_users_id__200.json"),
+		);
+		assertValid("GET /users/:id", data);
+		client.createUser(data.user);
+	},
 });
 
 Deno.test({
-  name: "Client/createUser: multiple users",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile("../example_data/GET_users__200.json"),
-    );
-    assertValid("GET /users", data);
+	name: "Client/createUser: multiple users",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile("../example_data/GET_users__200.json"),
+		);
+		assertValid("GET /users", data);
 
-    data.users.map(
-      (user) => client.createUser(user),
-    );
-  },
+		data.users.map(
+			(user) => client.createUser(user),
+		);
+	},
 });
 
 Deno.test({
-  name: "Client/createDeviceGroup: from multiple device groups",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile(
-        "../example_data/GET_devices_groups__200.json",
-      ),
-    );
-    assertValid("GET /devices/groups", data);
+	name: "Client/createDeviceGroup: from multiple device groups",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile(
+				"../example_data/GET_devices_groups__200.json",
+			),
+		);
+		assertValid("GET /devices/groups", data);
 
-    data.deviceGroups.map(
-      (user) => client.createDeviceGroup(user),
-    );
-  },
+		data.deviceGroups.map(
+			(user) => client.createDeviceGroup(user),
+		);
+	},
 });
 
 Deno.test({
-  name: "Client/createDeviceGroup: from single device group",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile(
-        "../example_data/GET_devices_groups_id__200.json",
-      ),
-    );
-    assertValid("GET /devices/groups/:id", data);
+	name: "Client/createDeviceGroup: from single device group",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile(
+				"../example_data/GET_devices_groups_id__200.json",
+			),
+		);
+		assertValid("GET /devices/groups/:id", data);
 
-    client.createDeviceGroup(data.deviceGroup);
-  },
+		client.createDeviceGroup(data.deviceGroup);
+	},
 });
 
 Deno.test({
-  name: "Client/createUserGroup: from multiple user groups",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile("../example_data/GET_users_groups__200.json"),
-    );
-    assertValid("GET /users/groups", data);
+	name: "Client/createUserGroup: from multiple user groups",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile("../example_data/GET_users_groups__200.json"),
+		);
+		assertValid("GET /users/groups", data);
 
-    data.groups.map(
-      (user) => client.createUserGroup(user),
-    );
-  },
+		data.groups.map(
+			(user) => client.createUserGroup(user),
+		);
+	},
 });
 
 Deno.test({
-  name: "Client/createUserGroup: from single user group",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile(
-        "../example_data/GET_users_groups_id__200.json",
-      ),
-    );
-    assertValid("GET /users/groups/:id", data);
+	name: "Client/createUserGroup: from single user group",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile(
+				"../example_data/GET_users_groups_id__200.json",
+			),
+		);
+		assertValid("GET /users/groups/:id", data);
 
-    client.createUserGroup(data.group);
-  },
+		client.createUserGroup(data.group);
+	},
 });
 
 Deno.test({
-  name: "Client/createApp: from multiple apps",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile("../example_data/GET_apps__200.json"),
-    );
-    assertValid("GET /apps", data);
+	name: "Client/createApp: from multiple apps",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile("../example_data/GET_apps__200.json"),
+		);
+		assertValid("GET /apps", data);
 
-    data.apps.map((app) => client.createApp(app));
-  },
+		data.apps.map((app) => client.createApp(app));
+	},
 });
 
 Deno.test({
-  name: "Client/createLocation: from multiple locations",
-  async fn() {
-    const data = JSON.parse(
-      await readRelativeTextFile("../example_data/GET_locations__200.json"),
-    );
-    assertValid("GET /locations", data);
+	name: "Client/createLocation: from multiple locations",
+	async fn() {
+		const data = JSON.parse(
+			await readRelativeTextFile("../example_data/GET_locations__200.json"),
+		);
+		assertValid("GET /locations", data);
 
-    data.locations.map((location) => client.createLocation(location));
-  },
+		data.locations.map((location) => client.createLocation(location));
+	},
 });

--- a/test/client/device.test.ts
+++ b/test/client/device.test.ts
@@ -8,29 +8,29 @@ const readRelativeTextFile = relativeTextFileReader(import.meta.url);
 const client = jamf.createClient({ id: "", token: "", url: "" });
 
 const data = JSON.parse(
-  await readRelativeTextFile("../example_data/GET_devices__200.json"),
+	await readRelativeTextFile("../example_data/GET_devices__200.json"),
 );
 assertValid("GET /devices", data);
 
 Deno.test({
-  name: "Device.toJSON() is the same as the data used to create it",
-  fn() {
-    const device = client.createDevice(data.devices[0]);
-    assertEquals(device.toJSON(), data.devices[0]);
-  },
+	name: "Device.toJSON() is the same as the data used to create it",
+	fn() {
+		const device = client.createDevice(data.devices[0]);
+		assertEquals(device.toJSON(), data.devices[0]);
+	},
 });
 
 Deno.test({
-  name: "Device.toString() is the same as Device.name",
-  fn() {
-    const device = client.createDevice(data.devices[0]);
-    assertEquals(device.toString(), device.name);
-  },
+	name: "Device.toString() is the same as Device.name",
+	fn() {
+		const device = client.createDevice(data.devices[0]);
+		assertEquals(device.toString(), device.name);
+	},
 });
 
 Deno.test({
-  name: "Device.enrollment is an object with 'type' and 'pending'",
-  fn() {
+	name: "Device.enrollment is an object with 'type' and 'pending'",
+	fn() {
 		for (const deviceData of data.devices) {
 			const device = client.createDevice(deviceData);
 			const obj = device.enrollment;
@@ -38,5 +38,5 @@ Deno.test({
 			assert("type" in obj);
 			assert("pending" in obj);
 		}
-  },
+	},
 });

--- a/test/client/device.test.ts
+++ b/test/client/device.test.ts
@@ -1,7 +1,7 @@
 import * as jamf from "../../src/mod.ts";
 import { assertValid } from "../../src/schemas/mod.ts";
 import { relativeTextFileReader } from "../deps/read_relative_file.ts";
-import { assertEquals } from "../deps/std_testing_asserts.ts";
+import { assert, assertEquals } from "../deps/std_testing_asserts.ts";
 
 const readRelativeTextFile = relativeTextFileReader(import.meta.url);
 
@@ -25,5 +25,18 @@ Deno.test({
   fn() {
     const device = client.createDevice(data.devices[0]);
     assertEquals(device.toString(), device.name);
+  },
+});
+
+Deno.test({
+  name: "Device.enrollment is an object with 'type' and 'pending'",
+  fn() {
+		for (const deviceData of data.devices) {
+			const device = client.createDevice(deviceData);
+			const obj = device.enrollment;
+			assert(typeof obj === "object");
+			assert("type" in obj);
+			assert("pending" in obj);
+		}
   },
 });

--- a/test/client/location.test.ts
+++ b/test/client/location.test.ts
@@ -8,22 +8,22 @@ const readRelativeTextFile = relativeTextFileReader(import.meta.url);
 const client = jamf.createClient({ id: "", token: "", url: "" });
 
 const data = JSON.parse(
-  await readRelativeTextFile("../example_data/GET_locations__200.json"),
+	await readRelativeTextFile("../example_data/GET_locations__200.json"),
 );
 assertValid("GET /locations", data);
 
 Deno.test({
-  name: "Location.toJSON() is the same as the data used to create it",
-  fn() {
-    const loc = client.createLocation(data.locations[0]);
-    assertEquals(loc.toJSON(), data.locations[0]);
-  },
+	name: "Location.toJSON() is the same as the data used to create it",
+	fn() {
+		const loc = client.createLocation(data.locations[0]);
+		assertEquals(loc.toJSON(), data.locations[0]);
+	},
 });
 
 Deno.test({
-  name: "Location.toString() is the same as Location.name",
-  fn() {
-    const loc = client.createLocation(data.locations[0]);
-    assertEquals(loc.toString(), loc.name);
-  },
+	name: "Location.toString() is the same as Location.name",
+	fn() {
+		const loc = client.createLocation(data.locations[0]);
+		assertEquals(loc.toString(), loc.name);
+	},
 });


### PR DESCRIPTION
Also documents the standardisation on American spelling. Australian English spells it as “enrolment”