### PR TITLE
feat: move users in bulk

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -98,11 +98,14 @@ Each entry explains what changed and links to a pull request that has more detai
 - **Added methods to edit a User/UserGroup/Device/DeviceGroup ([#58](https://github.com/SeparateRecords/deno_jamf_school/issues/58), [#61](https://github.com/SeparateRecords/deno_jamf_school/issues/61), [#62](https://github.com/SeparateRecords/deno_jamf_school/issues/62))** <br>
   Update multiple properties using an `API`, or more easily with the respective objects' `set` methods.
 
-- **Added methods to set User/Device locations ([#63](https://github.com/SeparateRecords/deno_jamf_school/issues/63))** <br>
-  Move individual users and devices, or move in bulk with `Location.moveDevices`. Search the docs for 'move' or 'location'.
+- **Added methods to set User/Device locations ([#63](https://github.com/SeparateRecords/deno_jamf_school/issues/63), [#66](https://github.com/SeparateRecords/deno_jamf_school/issues/66))** <br>
+  Move individual users and devices, or move in bulk with `Location` objects. Search the docs for 'move' or 'location'.
 
 - **Added `Client.getUserByUsername` ([#58](https://github.com/SeparateRecords/deno_jamf_school/issues/58))** <br>
   Usernames are inherently unique, so this makes it a reliable way to fetch users.
+
+- **Added `locationId` & `ownerId` property to relevant objects ([#66](https://github.com/SeparateRecords/deno_jamf_school/issues/66))** <br>
+  Makes it easier to use the objects and allows for better optimization.
 
 - **Renamed `API.assignDeviceOwner` ([#58](https://github.com/SeparateRecords/deno_jamf_school/issues/58))** <br>
   Now it's more consistent: `API.setDeviceOwner`
@@ -111,7 +114,7 @@ Each entry explains what changed and links to a pull request that has more detai
   The only property of the `DeviceGroup` objects used was `id`, and this update is aiming to make this style general.
 
 - **Improved how objects are displayed in the console ([#60](https://github.com/SeparateRecords/deno_jamf_school/issues/60))** <br>
-  Due to limitations with the implementation of `Deno.inspect`, indentation doesn't work properly.
+  `console.log(someDevices)` no longer results in `Device {}`! Indentation doesn't work properly due to some internal Deno stuff.
 
 ### Version 0.3.2
 

--- a/src/README.tpl.md
+++ b/src/README.tpl.md
@@ -95,11 +95,14 @@ Each entry explains what changed and links to a pull request that has more detai
 - **Added methods to edit a User/UserGroup/Device/DeviceGroup ($58, $61, $62)** <br>
   Update multiple properties using an `API`, or more easily with the respective objects' `set` methods.
 
-- **Added methods to set User/Device locations ($63)** <br>
-  Move individual users and devices, or move in bulk with `Location.moveDevices`. Search the docs for 'move' or 'location'.
+- **Added methods to set User/Device locations ($63, $66)** <br>
+  Move individual users and devices, or move in bulk with `Location` objects. Search the docs for 'move' or 'location'.
 
 - **Added `Client.getUserByUsername` ($58)** <br>
   Usernames are inherently unique, so this makes it a reliable way to fetch users.
+
+- **Added `locationId` & `ownerId` property to relevant objects ($66)** <br>
+  Makes it easier to use the objects and allows for better optimization.
 
 - **Renamed `API.assignDeviceOwner` ($58)** <br>
   Now it's more consistent: `API.setDeviceOwner`
@@ -108,7 +111,7 @@ Each entry explains what changed and links to a pull request that has more detai
   The only property of the `DeviceGroup` objects used was `id`, and this update is aiming to make this style general.
 
 - **Improved how objects are displayed in the console ($60)** <br>
-  Due to limitations with the implementation of `Deno.inspect`, indentation doesn't work properly.
+  `console.log(someDevices)` no longer results in `Device {}`! Indentation doesn't work properly due to some internal Deno stuff.
 
 ### Version 0.3.2
 

--- a/src/internal/App.ts
+++ b/src/internal/App.ts
@@ -73,6 +73,10 @@ export class App implements models.App {
 		return this.#data.version;
 	}
 
+	get locationId() {
+		return this.#data.locationId;
+	}
+
 	async getDevices() {
 		let devices;
 		try {

--- a/src/internal/Device.ts
+++ b/src/internal/Device.ts
@@ -117,6 +117,14 @@ export class Device implements models.Device {
 		return enrollment[this.#data.enrollType];
 	}
 
+	get locationId() {
+		return this.#data.locationId;
+	}
+
+	get ownerId() {
+		return this.#data.owner.id;
+	}
+
 	async update() {
 		const devices = await this.#api.getDevices({
 			serialNumber: this.#data.serialNumber,

--- a/src/internal/DeviceGroup.ts
+++ b/src/internal/DeviceGroup.ts
@@ -59,6 +59,10 @@ export class DeviceGroup implements models.DeviceGroup {
 		return this.#data.imageUrl;
 	}
 
+	get locationId() {
+		return this.#data.locationId;
+	}
+
 	// get isShared() {
 	// 	return this.data.shared;
 	// }

--- a/src/internal/Location.ts
+++ b/src/internal/Location.ts
@@ -159,18 +159,17 @@ export class Location implements models.Location {
 			return this;
 		}
 
-		// The API method doesn't do any de-duplication
-		const unique = [...new Set(udids)];
-
 		// Endpoint doesn't accept more than 20 devices per request, so chunking the
 		// array into groups of 20 and requesting in parallel is an easy workaround.
+		const unique = [...new Set(udids)]
 		const chunks = chunk(unique, 20);
-		await Promise.all(chunks.map((arr) => this.#api.moveDevices(arr, this.id)));
+		const promises = chunks.map((arr) => this.#api.moveDevices(arr, this.id));
+		await Promise.allSettled(promises);
 
 		return this;
 	}
 
-	async moveUsers(users: { id: number, locationId?: number }[]) {
+	async moveUsers(users: { id: number; locationId?: number }[]) {
 		const ids = users
 			.filter((user) => user.locationId !== this.id)
 			.map((user) => user.id);
@@ -179,9 +178,10 @@ export class Location implements models.Location {
 			return this;
 		}
 
-		const unique = [...new Set(ids)];
+		const unique = [...new Set(ids)]
+		const promises = unique.map((id) => this.#api.moveUser(id, this.id));
+		await Promise.allSettled(promises);
 
-		await Promise.all(unique.map((id) => this.#api.moveUser(id, this.id)));
 		return this;
 	}
 }

--- a/src/internal/Location.ts
+++ b/src/internal/Location.ts
@@ -145,19 +145,42 @@ export class Location implements models.Location {
 		return myApps.map((app) => this.#client.createApp(app));
 	}
 
-	async moveDevices(devices: { udid: string }[]) {
-		if (devices.length === 0) {
+	async moveDevices(devices: { udid: string; locationId?: number }[]) {
+		// This signature in the model doesn't specify locationId, but if the object
+		// *does* have it, we can optimize this further by filtering out the devices
+		// that wouldn't be moved
+		const udids = devices
+			.filter((device) => device.locationId !== this.id)
+			.map((device) => device.udid);
+
+		// It's possible that after the filter there wouldn't be any devices left, so
+		// it's cheaper to skip the network entirely and return now.
+		if (udids.length === 0) {
 			return this;
 		}
 
-		const udids = devices.map((device) => device.udid);
+		// The API method doesn't do any de-duplication
 		const unique = [...new Set(udids)];
+
+		// Endpoint doesn't accept more than 20 devices per request, so chunking the
+		// array into groups of 20 and requesting in parallel is an easy workaround.
 		const chunks = chunk(unique, 20);
-		const promises = chunks.map(
-			(arr) => this.#api.moveDevices(arr, this.id),
-		);
-		await Promise.all(promises);
+		await Promise.all(chunks.map((arr) => this.#api.moveDevices(arr, this.id)));
 
 		return this;
+	}
+
+	async moveUsers(users: { id: number, locationId?: number }[]) {
+		const ids = users
+			.filter((user) => user.locationId !== this.id)
+			.map((user) => user.id);
+
+		if (ids.length === 0) {
+			return this;
+		}
+
+		const unique = [...new Set(ids)];
+
+		await Promise.all(unique.map((id) => this.#api.moveUser(id, this.id)));
 	}
 }

--- a/src/internal/Location.ts
+++ b/src/internal/Location.ts
@@ -161,7 +161,7 @@ export class Location implements models.Location {
 
 		// Endpoint doesn't accept more than 20 devices per request, so chunking the
 		// array into groups of 20 and requesting in parallel is an easy workaround.
-		const unique = [...new Set(udids)]
+		const unique = [...new Set(udids)];
 		const chunks = chunk(unique, 20);
 		const promises = chunks.map((arr) => this.#api.moveDevices(arr, this.id));
 		await Promise.allSettled(promises);
@@ -178,7 +178,7 @@ export class Location implements models.Location {
 			return this;
 		}
 
-		const unique = [...new Set(ids)]
+		const unique = [...new Set(ids)];
 		const promises = unique.map((id) => this.#api.moveUser(id, this.id));
 		await Promise.allSettled(promises);
 

--- a/src/internal/Location.ts
+++ b/src/internal/Location.ts
@@ -182,5 +182,6 @@ export class Location implements models.Location {
 		const unique = [...new Set(ids)];
 
 		await Promise.all(unique.map((id) => this.#api.moveUser(id, this.id)));
+		return this;
 	}
 }

--- a/src/internal/User.ts
+++ b/src/internal/User.ts
@@ -77,6 +77,10 @@ export class User implements models.User {
 		return this.#data.exclude;
 	}
 
+	get locationId() {
+		return this.#data.locationId;
+	}
+
 	async update() {
 		// This shouldn't be wrapped in try/catch because its failure is an error
 		// the user should know about.

--- a/src/internal/UserGroup.ts
+++ b/src/internal/UserGroup.ts
@@ -81,6 +81,10 @@ export class UserGroup implements models.UserGroup {
 		return convertACLToStatus(this.#data.acl.teacher);
 	}
 
+	get locationId() {
+		return this.#data.locationId;
+	}
+
 	async update() {
 		this.#data = await this.#api.getUserGroup(this.#data.id);
 		return this;

--- a/src/models/App.ts
+++ b/src/models/App.ts
@@ -43,6 +43,9 @@ export interface App {
 	/** Whether or not the app is in the trash (deleted). */
 	readonly isTrashed: boolean;
 
+	/** The ID of this app's location. */
+	readonly locationId: number;
+
 	/** Return the data used to create this object. */
 	toJSON(): unknown;
 

--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -76,6 +76,12 @@ export interface Device {
 	/** The remaining charge as a percentage (number between 0 and 1) */
 	readonly batteryPercentage: number;
 
+	/** The ID of this device's location. */
+	readonly locationId: number;
+
+	/** The ID of this device's owner. */
+	readonly ownerId: number;
+
 	/**
 	 * The type of enrollment used for this device.
 	 *

--- a/src/models/DeviceGroup.ts
+++ b/src/models/DeviceGroup.ts
@@ -34,6 +34,9 @@ export interface DeviceGroup {
 	 */
 	readonly isSmartGroup: boolean;
 
+	/** The ID of this device group's location. */
+	readonly locationId: number;
+
 	// /**
 	//  * _If you know what this is, please raise an issue to tell me._
 	//  * https://github.com/SeparateRecords/deno_jamf_school/issues/new

--- a/src/models/Location.ts
+++ b/src/models/Location.ts
@@ -75,13 +75,12 @@ export interface Location {
 	update(): Promise<this>;
 
 	/**
-	 * (Edit) Move devices to this location.
-	 *
-	 * This will also move the device's owner and any other devices they own.
+	 * (Edit) Move devices to this location. This will also move the device's
+	 * owner and any other devices they own.
 	 *
 	 * Devices already in this location will not be affected.
 	 *
-	 * Note that failing to move a device is not a failure case.
+	 * Note that failing to move a device will not throw an exception.
 	 */
 	moveDevices(devices: { udid: string }[]): Promise<this>;
 
@@ -90,7 +89,7 @@ export interface Location {
 	 *
 	 * Users already in this location will not be affected.
 	 *
-	 * Note that failing to move a user is not a failure case.
+	 * Note that failing to move a user will not throw an exception.
 	 */
 	moveUsers(users: { id: number }[]): Promise<this>;
 }

--- a/src/models/Location.ts
+++ b/src/models/Location.ts
@@ -75,11 +75,18 @@ export interface Location {
 	update(): Promise<this>;
 
 	/**
-	 * (Edit) Move devices from their current location to this location.
+	 * (Edit) Move devices to this location.
 	 *
 	 * This will also move the device's owner and any other devices they own.
 	 *
 	 * Devices already in this location will not be affected.
 	 */
 	moveDevices(devices: { udid: string }[]): Promise<this>;
+
+	/**
+	 * (Edit) Move users and their devices to this location.
+	 *
+	 * Users already in this location will not be affected.
+	 */
+	moveUsers(users: { id: number }[]): Promise<this>;
 }

--- a/src/models/Location.ts
+++ b/src/models/Location.ts
@@ -80,6 +80,8 @@ export interface Location {
 	 * This will also move the device's owner and any other devices they own.
 	 *
 	 * Devices already in this location will not be affected.
+	 *
+	 * Note that failing to move a device is not a failure case.
 	 */
 	moveDevices(devices: { udid: string }[]): Promise<this>;
 
@@ -87,6 +89,8 @@ export interface Location {
 	 * (Edit) Move users and their devices to this location.
 	 *
 	 * Users already in this location will not be affected.
+	 *
+	 * Note that failing to move a user is not a failure case.
 	 */
 	moveUsers(users: { id: number }[]): Promise<this>;
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -39,6 +39,9 @@ export interface User {
 	/** Whether the user is excluded from teacher restrictions. */
 	readonly isExcludedFromRestrictions: boolean;
 
+	/** The ID of this user's location. */
+	readonly locationId: number;
+
 	/** Return the data used to create this object. */
 	toJSON(): unknown;
 

--- a/src/models/UserGroup.ts
+++ b/src/models/UserGroup.ts
@@ -23,6 +23,9 @@ export interface UserGroup {
 	/** Whether the users in this group are teachers. */
 	readonly isTeacherGroup: boolean | null;
 
+	/** The ID of this user group's location. */
+	readonly locationId: number;
+
 	/** Return the data used to create this object. */
 	toJSON(): unknown;
 


### PR DESCRIPTION
This PR adds `Location.moveUsers` and exposes the `locationId` property on relevant objects.

<details>
<summary>It’s also the first instance of a pattern I think I’ll be using a lot more…</summary>

For context;
1. The library is divided into the public-facing “models” and the internal implementations.
2. Where objects’ methods would take another object, instead they use TypeScript’s great structural typing, which allows you to call a method using an object literal instead. 

This means adding “progressive enhancement” is actually _really_ easy, since in the implementation you can just declare a property as optional and behave differently based on whether it’s present.

Here’s an example:
```typescript
export interface A {
  method(data: { id: number }): void;
}
```
```typescript
import type * as models from "./models.ts";

export class A implements models.A {
  // The interface doesn’t specify `isSpecial` as a property, so it
  // won’t appear in docs or editor suggestions.
  method(data: { id: number, isSpecial?: boolean }) {
    // do something different if the `data` object has `isSpecial`
  }
}
```

In practise, this means methods that take objects can implement additional optimisations _if the argument is that kind of object_ but still _have_ to fall back on a sane default behaviour if it’s an object literal (otherwise it wouldn’t be compliant with the interface).

This PR uses this kind of progressive enhancement to optimise moving users by completely skipping users where the `locationId` is the same as the location they’re moving to.

</details>