### PR TITLE
feat: restart a user's devices

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -91,6 +91,13 @@ await Promise.allSettled(devices.map((device) => device.restart()));
 
 Each entry explains what changed and links to a pull request that has more details.
 
+### Version 0.4.1
+
+<!-- deno-fmt-ignore -->
+
+- **Added `User.restartDevices()` ([#73](https://github.com/SeparateRecords/deno_jamf_school/issues/73))** <br>
+  Users contain devices, so this makes the API more consistent.
+
 ### Version 0.4.0
 
 <!-- deno-fmt-ignore -->
@@ -122,15 +129,15 @@ Each entry explains what changed and links to a pull request that has more detai
 - **Breaking: Methods that returned `Promise<this>` now return `Promise<void>` ([#68](https://github.com/SeparateRecords/deno_jamf_school/issues/68))** <br>
   Returning `this` is unexpected and encourages worse code than returning nothing at all.
 
+<details>
+<summary>Older versions</summary>
+
 ### Version 0.3.2
 
 <!-- deno-fmt-ignore -->
 
 - **Improved the implementation of `Device.enrollment` ([#56](https://github.com/SeparateRecords/deno_jamf_school/issues/56))** <br>
   This should be marginally faster. The "manual" type now also includes a `pending` property (currently always `false`).
-
-<details>
-<summary>Older versions</summary>
 
 ### Version 0.3.1
 

--- a/src/README.tpl.md
+++ b/src/README.tpl.md
@@ -88,6 +88,13 @@ await Promise.allSettled(devices.map((device) => device.restart()));
 
 Each entry explains what changed and links to a pull request that has more details.
 
+### Version 0.4.1
+
+<!-- deno-fmt-ignore -->
+
+- **Added `User.restartDevices()` ($73)** <br>
+  Users contain devices, so this makes the API more consistent.
+
 ### Version 0.4.0
 
 <!-- deno-fmt-ignore -->
@@ -119,15 +126,15 @@ Each entry explains what changed and links to a pull request that has more detai
 - **Breaking: Methods that returned `Promise<this>` now return `Promise<void>` ($68)** <br>
   Returning `this` is unexpected and encourages worse code than returning nothing at all.
 
+<details>
+<summary>Older versions</summary>
+
 ### Version 0.3.2
 
 <!-- deno-fmt-ignore -->
 
 - **Improved the implementation of `Device.enrollment` ($56)** <br>
   This should be marginally faster. The "manual" type now also includes a `pending` property (currently always `false`).
-
-<details>
-<summary>Older versions</summary>
 
 ### Version 0.3.1
 

--- a/src/internal/User.ts
+++ b/src/internal/User.ts
@@ -179,4 +179,10 @@ export class User implements models.User {
 		await this.#api.moveUser(this.id, location.id);
 		return;
 	}
+
+	async restartDevices() {
+		const devices = await this.#api.getDevices({ ownerId: this.id });
+		const promises = devices.map((device) => this.#api.restartDevice(device.UDID));
+		await Promise.all(promises);
+	}
 }

--- a/src/internal/User.ts
+++ b/src/internal/User.ts
@@ -172,6 +172,6 @@ export class User implements models.User {
 	async restartDevices() {
 		const devices = await this.#api.getDevices({ ownerId: this.id });
 		const promises = devices.map((device) => this.#api.restartDevice(device.UDID));
-		await Promise.all(promises);
+		await Promise.allSettled(promises);
 	}
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -144,4 +144,11 @@ export interface User {
 	 * `User.update()`.
 	 */
 	setChildren(children: { id: number }[]): Promise<void>;
+
+	/**
+	 * (Read, Add) Restart all this user's devices.
+	 *
+	 * Note that failing to restart a device will not throw an exception.
+	 */
+	restartDevices(): Promise<void>;
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -146,7 +146,7 @@ export interface User {
 	setChildren(children: { id: number }[]): Promise<void>;
 
 	/**
-	 * (Read, Add) Restart all this user's devices.
+	 * (Read, Add) Restart all of this user's devices.
 	 *
 	 * Note that failing to restart a device will not throw an exception.
 	 */


### PR DESCRIPTION
The pattern I'm going for is that any "device container" (an object with a `getDevices()` method) is also able to restart the devices it contains. User objects were the odd one out - unlike locations and device groups, users contain devices but were not able to restart them all with a single method call. This PR fixes that inconsistency.